### PR TITLE
Fixed a wrong naming of a variable in the .json

### DIFF
--- a/LWTNN_network_v7.json
+++ b/LWTNN_network_v7.json
@@ -31,7 +31,7 @@
       "scale": 1
     },
     {
-      "name": "trk_dzClosestPVNorm",
+      "name": "trk_dzClosestPVClamped",
       "offset": 0,
       "scale": 1
     },


### PR DESCRIPTION
Fixed a wrong naming of variable 'trk_dzClosestPVNorm' to 'trk_dzClosestPVClamped'